### PR TITLE
Add support for uuid columns

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -30,6 +30,7 @@ export class Database {
             switch (udtName) {
                 case 'varchar':
                 case 'text':
+                case 'uuid':
                     return 'string'
                 case 'int2':
                 case 'int4':

--- a/test/example/osm.ts
+++ b/test/example/osm.ts
@@ -40,7 +40,7 @@ export namespace osm {
         export type image_use_gravatar = boolean;
         export type image_content_type = string;
         export type auth_provider = string;
-        export type uuid_column=string;
+        export type uuid_column = string;
     }
 
     export interface users {

--- a/test/example/osm.ts
+++ b/test/example/osm.ts
@@ -40,7 +40,7 @@ export namespace osm {
         export type image_use_gravatar = boolean;
         export type image_content_type = string;
         export type auth_provider = string;
-
+        export type uuid_column=string;
     }
 
     export interface users {
@@ -73,7 +73,7 @@ export namespace osm {
         image_use_gravatar: usersFields.image_use_gravatar;
         image_content_type: usersFields.image_content_type;
         auth_provider: usersFields.auth_provider;
-
+        uuid_column: usersFields.uuid_column;
     }
 
 }

--- a/test/example/osm.ts
+++ b/test/example/osm.ts
@@ -41,6 +41,7 @@ export namespace osm {
         export type image_content_type = string;
         export type auth_provider = string;
         export type uuid_column = string;
+
     }
 
     export interface users {
@@ -74,6 +75,7 @@ export namespace osm {
         image_content_type: usersFields.image_content_type;
         auth_provider: usersFields.auth_provider;
         uuid_column: usersFields.uuid_column;
+
     }
 
 }

--- a/test/osm_schema.sql
+++ b/test/osm_schema.sql
@@ -48,7 +48,8 @@ CREATE TABLE users (
     diary_entries_count integer DEFAULT 0 NOT NULL,
     image_use_gravatar boolean DEFAULT false NOT NULL,
     image_content_type character varying(255),
-    auth_provider character varying
+    auth_provider character varying,
+    uuid_column uuid
 );
 
 


### PR DESCRIPTION
This PR will add support for columns with the UUID type. Since there is no native UUID type in javascript the UUID is converted to a string.

In the SQL schema used for the test I added a new column with the UUID type. 