### PR TITLE
Add more datatypes

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -45,28 +45,38 @@ export class Database {
         return mapValues(tableDefinition, udtName => {
             switch (udtName) {
                 case 'bpchar':
+                case 'char':
                 case 'varchar':
                 case 'text':
                 case 'uuid':
                 case 'bytea':
+                case 'inet':
+                case 'time':
+                case 'timetz':
+                case 'interval':
                     return 'string'
                 case 'int2':
                 case 'int4':
                 case 'int8':
+                case 'float4':
                 case 'float8':
                 case 'numeric':
                 case 'money':
+                case 'oid':
                     return 'number'
                 case 'bool':
                     return 'boolean'
                 case 'json':
+                case 'jsonb':
                     return 'Object'
                 case 'date':
                 case 'timestamp':
+                case 'timestamptz':
                     return 'Date'
                 case '_int2':
                 case '_int4':
                 case '_int8':
+                case '_float4':
                 case '_float8':
                 case '_numeric':
                 case '_money':

--- a/test/example/osm.ts
+++ b/test/example/osm.ts
@@ -45,6 +45,9 @@ export namespace osm {
         export type string_ = string;
         export type money_col = number;
         export type char_col = string;
+        export type time_col = string;
+        export type inet_col = string;
+        export type jsonb_col = Object;
         export type numeric_col = number;
         export type bytea_col = string;
         export type bool_array_col = Array<boolean>;
@@ -55,6 +58,11 @@ export namespace osm {
         export type uuid_array_col = Array<string>;
         export type text_array_col = Array<string>;
         export type bytea_array_col = Array<string>;
+        export type real_col = number;
+        export type double_col = number;
+        export type time_with_tz = string;
+        export type oid_col = number;
+        export type interval_col = string;
 
     }
 
@@ -93,6 +101,9 @@ export namespace osm {
         string: usersFields.string_;
         money_col: usersFields.money_col;
         char_col: usersFields.char_col;
+        time_col: usersFields.time_col;
+        inet_col: usersFields.inet_col;
+        jsonb_col: usersFields.jsonb_col;
         numeric_col: usersFields.numeric_col;
         bytea_col: usersFields.bytea_col;
         bool_array_col: usersFields.bool_array_col;
@@ -103,6 +114,11 @@ export namespace osm {
         uuid_array_col: usersFields.uuid_array_col;
         text_array_col: usersFields.text_array_col;
         bytea_array_col: usersFields.bytea_array_col;
+        real_col: usersFields.real_col;
+        double_col: usersFields.double_col;
+        time_with_tz: usersFields.time_with_tz;
+        oid_col: usersFields.oid_col;
+        interval_col: usersFields.interval_col;
 
     }
 

--- a/test/osm_schema.sql
+++ b/test/osm_schema.sql
@@ -54,6 +54,9 @@ CREATE TABLE users (
     string character varying,
     money_col money,
     char_col char,
+    time_col time,
+    inet_col inet,
+    jsonb_col jsonb,
     numeric_col numeric(5,2),
     bytea_col bytea,
     bool_array_col boolean[],
@@ -63,7 +66,12 @@ CREATE TABLE users (
     int8_array_col int8[],
     uuid_array_col uuid[],
     text_array_col text[],
-    bytea_array_col bytea[]
+    bytea_array_col bytea[],
+    real_col real,
+    double_col double precision,
+    time_with_tz time with time zone,
+    oid_col oid,
+    interval_col interval
 );
 
 


### PR DESCRIPTION
Add more datatypes in mapping.
oid is mapped to number type because it is implemented as a unsigned 4 digits integer in postgres (I don't know if the implementation in other databases differs).

I failed to find an official table of all udt datatypes (information_schema is ANSI standard) so probably not all the udt types are covered, but now we have the most frequent ones.

FWIW, this PR covers all the datatypes added in gust/schemats enum implementation.
