### PR TITLE
Pass namespace as null for tests, and allow null in typescriptOfSchema, fix #35

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export function getTime() {
     return `${yyyy}-${MM}-${dd} ${hh}:${mm}:${ss}`
 }
 
-export async function typescriptOfSchema(db: Database, namespace: string, tables: string[], schema: string|null = 'public',
+export async function typescriptOfSchema(db: Database, namespace: string|null, tables: string[], schema: string|null = 'public',
                                          commandRan: string, time: string): Promise<string> {
     if (namespace) {
         console.warn('[DEPRECATED] Generation schema with namespace is deprecated.')

--- a/test/test.ts
+++ b/test/test.ts
@@ -46,7 +46,7 @@ async function testGeneratingTables(db: Database) {
     let outputFile = (process.env.CIRCLE_ARTIFACTS || './test/artifacts') + '/osm.ts'
     let formattedOutput = await typescriptOfSchema(
         db,
-        undefined,
+        null,
         ['users'],
         null,
         extractCommand(


### PR DESCRIPTION
It's now allowed to pass null for namespace parameter.
Namespace was passed undefined in tests, so I changed to null, it's seems more logical.
