### PR TITLE
Use upstream typescript-formatter@4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tslint": "^3.15.1",
     "tslint-config-standard": "^1.3.0",
     "typescript": "^2.1.5",
-    "@xiamx/typescript-formatter": "4.1.0",
+    "typescript-formatter": "4.1.1",
     "yargs": "^6.5.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
 
 import {generateEnumType, generateTableTypes, generateTableInterface} from './typescript'
 import {Database} from './schema'
-import {processString} from '@xiamx/typescript-formatter'
+import {processString} from 'typescript-formatter'
 
 export async function typescriptOfTable(db: Database, table: string, schema: string) {
     let interfaces = ''


### PR DESCRIPTION
Hotfix made for https://github.com/SweetIQ/schemats/issues/37 has now been merged to the upstream project typescript-formatter We are switching back to use the version 4.1.1 of upstream release.