### PR TITLE
Fix for new ts.formatting.RulesProvider error

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "mysql": "^2.13.0",
     "mz": "^2.6.0",
     "pg-promise": "^6.3.6",
-    "typescript": "^2.4.2",
-    "typescript-formatter": "4.1.1",
+    "typescript": "^2.7.1",
+    "typescript-formatter": "^7.0.1",
     "yargs": "^8.0.1"
   },
   "nyc": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
 import { generateEnumType, generateTableTypes, generateTableInterface } from './typescript'
 import { getDatabase, Database } from './schema'
 import Options, { OptionValues } from './options'
-import { processString } from 'typescript-formatter'
+import { processString, Options as ITFOptions } from 'typescript-formatter'
 const pkgVersion = require('../package.json').version
 
 function getTime () {
@@ -90,13 +90,18 @@ export async function typescriptOfSchema (db: Database|string,
     output += enumTypes
     output += interfaces
 
-    let formatterOption = {
+    const formatterOption: ITFOptions = {
         replace: false,
         verify: false,
         tsconfig: true,
         tslint: true,
         editorconfig: true,
-        tsfmt: true
+        tsfmt: true,
+        vscode: false,
+        tsconfigFile: null,
+        tslintFile: null,
+        vscodeFile: null,
+        tsfmtFile: null
     }
 
     const processedResult = await processString('schema.ts', output, formatterOption)

--- a/src/schemaMysql.ts
+++ b/src/schemaMysql.ts
@@ -1,5 +1,5 @@
 import * as mysql from 'mysql'
-import { mapValues, keys, isEqual, camelCase } from 'lodash'
+import { mapValues, keys, isEqual } from 'lodash'
 import { parse as urlParse } from 'url'
 import { TableDefinition, Database } from './schemaInterfaces'
 import Options from './options'


### PR DESCRIPTION
Fix `Schemats failed to generate the database schema TypeError: ts.formatting.RulesProvider is not a constructor` errors probably coming from the new typescript release