### PR TITLE
Postgres infinity timestamps

### DIFF
--- a/src/schemaPostgres.ts
+++ b/src/schemaPostgres.ts
@@ -51,7 +51,7 @@ export class PostgresDatabase implements Database {
                 case 'date':
                 case 'timestamp':
                 case 'timestamptz':
-                    column.tsType = 'Date | \'infinity\''
+                    column.tsType = 'Date | Infinity'
                     return column
                 case '_int2':
                 case '_int4':
@@ -77,7 +77,7 @@ export class PostgresDatabase implements Database {
                     column.tsType = 'Array<Object>'
                     return column
                 case '_timestamptz':
-                    column.tsType = 'Array<Date | \'infinity\'>'
+                    column.tsType = 'Array<Date | Infinity>'
                     return column
                 default:
                     if (customTypes.indexOf(column.udtName) !== -1) {

--- a/src/schemaPostgres.ts
+++ b/src/schemaPostgres.ts
@@ -51,7 +51,7 @@ export class PostgresDatabase implements Database {
                 case 'date':
                 case 'timestamp':
                 case 'timestamptz':
-                    column.tsType = 'Date'
+                    column.tsType = 'Date | \'infinity\''
                     return column
                 case '_int2':
                 case '_int4':
@@ -67,7 +67,7 @@ export class PostgresDatabase implements Database {
                     return column
                 case '_varchar':
                 case '_text':
-                case '_citext':                    
+                case '_citext':
                 case '_uuid':
                 case '_bytea':
                     column.tsType = 'Array<string>'
@@ -77,7 +77,7 @@ export class PostgresDatabase implements Database {
                     column.tsType = 'Array<Object>'
                     return column
                 case '_timestamptz':
-                    column.tsType = 'Array<Date>'
+                    column.tsType = 'Array<Date | \'infinity\'>'
                     return column
                 default:
                     if (customTypes.indexOf(column.udtName) !== -1) {

--- a/test/expected/postgres/osm-camelcase.ts
+++ b/test/expected/postgres/osm-camelcase.ts
@@ -7,7 +7,7 @@ export namespace UsersFields {
     export type email = string;
     export type id = number;
     export type passCrypt = string;
-    export type creationTime = Date;
+    export type creationTime = Date | 'infinity';
     export type displayName = string;
     export type dataPublic = boolean;
     export type description = string;
@@ -22,7 +22,7 @@ export namespace UsersFields {
     export type creationIp = string | null;
     export type languages = string | null;
     export type status = UserStatusEnum;
-    export type termsAgreed = Date | null;
+    export type termsAgreed = Date | 'infinity' | null;
     export type considerPd = boolean;
     export type preferredEditor = string | null;
     export type termsSeen = boolean;
@@ -64,7 +64,7 @@ export namespace UsersFields {
     export type nameTypeCol = string | null;
     export type jsonArrayCol = Array<Object> | null;
     export type jsonbArrayCol = Array<Object> | null;
-    export type timestamptzArrayCol = Array<Date> | null;
+    export type timestamptzArrayCol = Array<Date | 'infinity'> | null;
 
 }
 

--- a/test/expected/postgres/osm-camelcase.ts
+++ b/test/expected/postgres/osm-camelcase.ts
@@ -7,7 +7,7 @@ export namespace UsersFields {
     export type email = string;
     export type id = number;
     export type passCrypt = string;
-    export type creationTime = Date | 'infinity';
+    export type creationTime = Date | Infinity;
     export type displayName = string;
     export type dataPublic = boolean;
     export type description = string;
@@ -22,7 +22,7 @@ export namespace UsersFields {
     export type creationIp = string | null;
     export type languages = string | null;
     export type status = UserStatusEnum;
-    export type termsAgreed = Date | 'infinity' | null;
+    export type termsAgreed = Date | Infinity | null;
     export type considerPd = boolean;
     export type preferredEditor = string | null;
     export type termsSeen = boolean;
@@ -64,7 +64,7 @@ export namespace UsersFields {
     export type nameTypeCol = string | null;
     export type jsonArrayCol = Array<Object> | null;
     export type jsonbArrayCol = Array<Object> | null;
-    export type timestamptzArrayCol = Array<Date | 'infinity'> | null;
+    export type timestamptzArrayCol = Array<Date | Infinity> | null;
 
 }
 

--- a/test/expected/postgres/osm.ts
+++ b/test/expected/postgres/osm.ts
@@ -7,7 +7,7 @@ export namespace usersFields {
     export type email = string;
     export type id = number;
     export type pass_crypt = string;
-    export type creation_time = Date | 'infinity';
+    export type creation_time = Date | Infinity;
     export type display_name = string;
     export type data_public = boolean;
     export type description = string;
@@ -22,7 +22,7 @@ export namespace usersFields {
     export type creation_ip = string | null;
     export type languages = string | null;
     export type status = user_status_enum;
-    export type terms_agreed = Date | 'infinity' | null;
+    export type terms_agreed = Date | Infinity | null;
     export type consider_pd = boolean;
     export type preferred_editor = string | null;
     export type terms_seen = boolean;
@@ -59,12 +59,12 @@ export namespace usersFields {
     export type oid_col = number | null;
     export type interval_col = string | null;
     export type json_col = Object | null;
-    export type date_col = Date | 'infinity' | null;
+    export type date_col = Date | Infinity | null;
     export type unspported_path_type = any | null;
     export type name_type_col = string | null;
     export type json_array_col = Array<Object> | null;
     export type jsonb_array_col = Array<Object> | null;
-    export type timestamptz_array_col = Array<Date | 'infinity'> | null;
+    export type timestamptz_array_col = Array<Date | Infinity> | null;
 
 }
 

--- a/test/expected/postgres/osm.ts
+++ b/test/expected/postgres/osm.ts
@@ -7,7 +7,7 @@ export namespace usersFields {
     export type email = string;
     export type id = number;
     export type pass_crypt = string;
-    export type creation_time = Date;
+    export type creation_time = Date | 'infinity';
     export type display_name = string;
     export type data_public = boolean;
     export type description = string;
@@ -22,7 +22,7 @@ export namespace usersFields {
     export type creation_ip = string | null;
     export type languages = string | null;
     export type status = user_status_enum;
-    export type terms_agreed = Date | null;
+    export type terms_agreed = Date | 'infinity' | null;
     export type consider_pd = boolean;
     export type preferred_editor = string | null;
     export type terms_seen = boolean;
@@ -59,12 +59,12 @@ export namespace usersFields {
     export type oid_col = number | null;
     export type interval_col = string | null;
     export type json_col = Object | null;
-    export type date_col = Date | null;
+    export type date_col = Date | 'infinity' | null;
     export type unspported_path_type = any | null;
     export type name_type_col = string | null;
     export type json_array_col = Array<Object> | null;
     export type jsonb_array_col = Array<Object> | null;
-    export type timestamptz_array_col = Array<Date> | null;
+    export type timestamptz_array_col = Array<Date | 'infinity'> | null;
 
 }
 

--- a/test/unit/schemaPostgres.test.ts
+++ b/test/unit/schemaPostgres.test.ts
@@ -192,7 +192,7 @@ describe('PostgresDatabase', () => {
                     }
                 }
                 assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'string')
-            })            
+            })
             it('uuid', () => {
                 const td: TableDefinition = {
                     column: {
@@ -362,7 +362,7 @@ describe('PostgresDatabase', () => {
                 assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Object')
             })
         })
-        describe('maps to Date', () => {
+        describe('maps to Date or infinity', () => {
             it('date', () => {
                 const td: TableDefinition = {
                     column: {
@@ -370,7 +370,7 @@ describe('PostgresDatabase', () => {
                         nullable: false
                     }
                 }
-                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date')
+                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date | \'infinity\'')
             })
             it('timestamp', () => {
                 const td: TableDefinition = {
@@ -379,7 +379,7 @@ describe('PostgresDatabase', () => {
                         nullable: false
                     }
                 }
-                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date')
+                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date | \'infinity\'')
             })
             it('timestamptz', () => {
                 const td: TableDefinition = {
@@ -388,7 +388,7 @@ describe('PostgresDatabase', () => {
                         nullable: false
                     }
                 }
-                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date')
+                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date | \'infinity\'')
             })
         })
         describe('maps to Array<number>', () => {
@@ -494,7 +494,7 @@ describe('PostgresDatabase', () => {
                     }
                 }
                 assert.equal(PostgresDBReflection.mapTableDefinitionToType(td, ['CustomType'], options).column.tsType, 'Array<string>')
-            })            
+            })
             it('_uuid', () => {
                 const td: TableDefinition = {
                     column: {
@@ -514,7 +514,7 @@ describe('PostgresDatabase', () => {
                 assert.equal(PostgresDBReflection.mapTableDefinitionToType(td, ['CustomType'], options).column.tsType, 'Array<string>')
             })
         })
-        
+
         describe('maps to Array<Object>', () => {
             it('_json', () => {
                 const td: TableDefinition = {
@@ -535,8 +535,8 @@ describe('PostgresDatabase', () => {
                 assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Array<Object>')
             })
         })
-        
-        describe('maps to Array<Date>', () => {
+
+        describe('maps to Array<Date | \'infinity\'>', () => {
             it('_timestamptz', () => {
                 const td: TableDefinition = {
                     column: {
@@ -544,10 +544,10 @@ describe('PostgresDatabase', () => {
                         nullable: false
                     }
                 }
-                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Array<Date>')
+                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Array<Date | \'infinity\'>')
             })
         })
-        
+
         describe('maps to custom', () => {
             it('CustomType', () => {
                 const td: TableDefinition = {

--- a/test/unit/schemaPostgres.test.ts
+++ b/test/unit/schemaPostgres.test.ts
@@ -362,7 +362,7 @@ describe('PostgresDatabase', () => {
                 assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Object')
             })
         })
-        describe('maps to Date or infinity', () => {
+        describe('maps to Date or Infinity', () => {
             it('date', () => {
                 const td: TableDefinition = {
                     column: {
@@ -370,7 +370,7 @@ describe('PostgresDatabase', () => {
                         nullable: false
                     }
                 }
-                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date | \'infinity\'')
+                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date | Infinity')
             })
             it('timestamp', () => {
                 const td: TableDefinition = {
@@ -379,7 +379,7 @@ describe('PostgresDatabase', () => {
                         nullable: false
                     }
                 }
-                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date | \'infinity\'')
+                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date | Infinity')
             })
             it('timestamptz', () => {
                 const td: TableDefinition = {
@@ -388,7 +388,7 @@ describe('PostgresDatabase', () => {
                         nullable: false
                     }
                 }
-                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date | \'infinity\'')
+                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Date | Infinity')
             })
         })
         describe('maps to Array<number>', () => {
@@ -536,7 +536,7 @@ describe('PostgresDatabase', () => {
             })
         })
 
-        describe('maps to Array<Date | \'infinity\'>', () => {
+        describe('maps to Array<Date | Infinity>', () => {
             it('_timestamptz', () => {
                 const td: TableDefinition = {
                     column: {
@@ -544,7 +544,7 @@ describe('PostgresDatabase', () => {
                         nullable: false
                     }
                 }
-                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Array<Date | \'infinity\'>')
+                assert.equal(PostgresDBReflection.mapTableDefinitionToType(td,[],options).column.tsType, 'Array<Date | Infinity>')
             })
         })
 


### PR DESCRIPTION
PostgreSQL supports the value of 'infinity' for the data types timestamp and timestamptz. The Postgres driver for NodeJS reads this value as Infinity of type Number. This change allows schemats to interpret this value by expanding the type mapping for timestamps to include the value Infinity.