### PR TITLE
Add mapping for custom enum array types in postgres

### DIFF
--- a/src/schemaPostgres.ts
+++ b/src/schemaPostgres.ts
@@ -83,6 +83,9 @@ export class PostgresDatabase implements Database {
                     if (customTypes.indexOf(column.udtName) !== -1) {
                         column.tsType = options.transformTypeName(column.udtName)
                         return column
+                    } else if(customTypes.map(type => `_${type}`).indexOf(column.udtName) !== -1) {
+                        column.tsType = `Array<${options.transformTypeName(column.udtName)}>`
+                        return column
                     } else {
                         console.log(`Type [${column.udtName} has been mapped to [any] because no specific type has been found.`)
                         column.tsType = 'any'

--- a/test/expected/postgres/osm.ts
+++ b/test/expected/postgres/osm.ts
@@ -65,6 +65,7 @@ export namespace usersFields {
     export type json_array_col = Array<Object> | null;
     export type jsonb_array_col = Array<Object> | null;
     export type timestamptz_array_col = Array<Date> | null;
+    export type formats = Array<format_enum> | null;
 
 }
 
@@ -130,4 +131,5 @@ export interface users {
     json_array_col: usersFields.json_array_col;
     jsonb_array_col: usersFields.jsonb_array_col;
     timestamptz_array_col: usersFields.timestamptz_array_col;
+    formats: usersFields.formats;
 }

--- a/test/fixture/postgres/osm.sql
+++ b/test/fixture/postgres/osm.sql
@@ -77,5 +77,6 @@ CREATE TABLE users (
     name_type_col name,
     json_array_col json[],
     jsonb_array_col jsonb[],
-    timestamptz_array_col timestamptz[]
+    timestamptz_array_col timestamptz[],
+    formats format_enum[]
 );


### PR DESCRIPTION
I added support for Postgres enum types as array, e.g. `formats format_enum[]` generates `export type formats = Array<format_enum> | null;` with this change. Before, it would yield `any`.

Unfortunately, the linting part of the tests even failed before the changes were made.