### PR TITLE
Update reserved word list

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -10,9 +10,71 @@ import Options from './options'
 
 function nameIsReservedKeyword (name: string): boolean {
     const reservedKeywords = [
-        'string',
+        // Reserved Words
+        'break',
+        'case',
+        'catch',
+        'class',
+        'const',
+        'continue',
+        'debugger',
+        'default',
+        'delete',
+        'do',
+        'else',
+        'enum',
+        'export',
+        'extends',
+        'false',
+        'finally',
+        'for',
+        'function',
+        'if',
+        'import',
+        'in',
+        'instanceof',
+        'new',
+        'null',
+        'return',
+        'super',
+        'switch',
+        'this',
+        'throw',
+        'true',
+        'try',
+        'typeof',
+        'var',
+        'void',
+        'while',
+        'with',
+
+        // Strict Mode Reserved Words
+        'as',
+        'implements',
+        'interface',
+        'let',
+        'package',
+        'private',
+        'protected',
+        'public',
+        'static',
+        'yield',
+
+        // Contextual Keywords
+        'any',
+        'boolean',
+        'constructor',
+        'declare',
+        'get',
+        'module',
+        'require',
         'number',
-        'package'
+        'set',
+        'string',
+        'symbol',
+        'type',
+        'from',
+        'of'
     ]
     return reservedKeywords.indexOf(name) !== -1
 }

--- a/test/integration/cli.test.ts
+++ b/test/integration/cli.test.ts
@@ -11,7 +11,7 @@ describe('schemats cli tool integration testing', () => {
         it('should run without error', () => {
             let {status, stdout, stderr} = spawnSync('node', [
                 'bin/schemats', 'generate',
-                '-c', process.env.POSTGRES_URL,
+                '-c', process.env.POSTGRES_URL as string,
                 '-o', '/tmp/schemats_cli_postgres.ts'
             ], { encoding: 'utf-8' })
             console.log('opopopopop', stdout, stderr)
@@ -27,7 +27,7 @@ describe('schemats cli tool integration testing', () => {
         it('should run without error', () => {
             let {status} = spawnSync('node', [
                 'bin/schemats', 'generate',
-                '-c', process.env.MYSQL_URL,
+                '-c', process.env.MYSQL_URL as string,
                 '-s', 'test',
                 '-o', '/tmp/schemats_cli_postgres.ts'
             ])


### PR DESCRIPTION
The existing logic appends an underscore after column names that are in the reserved word list but the reserved word list is incomplete. I updated the reserved word list obtained from https://github.com/Microsoft/TypeScript/issues/2536

I also fix an issue cause `tsc` unable to complete due to missing type cast.