### PR TITLE
Fix enum name collision issue by changing naming convention

### DIFF
--- a/test/integration/cli.test.ts
+++ b/test/integration/cli.test.ts
@@ -11,7 +11,7 @@ describe('schemats cli tool integration testing', () => {
         it('should run without error', () => {
             let {status, stdout, stderr} = spawnSync('node', [
                 'bin/schemats', 'generate',
-                '-c', process.env.POSTGRES_URL,
+                '-c', process.env.POSTGRES_URL as string,
                 '-o', '/tmp/schemats_cli_postgres.ts'
             ], { encoding: 'utf-8' })
             console.log('opopopopop', stdout, stderr)
@@ -27,7 +27,7 @@ describe('schemats cli tool integration testing', () => {
         it('should run without error', () => {
             let {status} = spawnSync('node', [
                 'bin/schemats', 'generate',
-                '-c', process.env.MYSQL_URL,
+                '-c', process.env.MYSQL_URL as string,
                 '-s', 'test',
                 '-o', '/tmp/schemats_cli_postgres.ts'
             ])

--- a/test/unit/schemaMysql.test.ts
+++ b/test/unit/schemaMysql.test.ts
@@ -66,7 +66,7 @@ describe('MysqlDatabase', () => {
             MysqlDBReflection.prototype.queryAsync.returns(Promise.resolve([]))
             await db.getEnumTypes('testschema')
             assert.deepEqual(MysqlDBReflection.prototype.queryAsync.getCall(0).args, [
-                'SELECT column_name, column_type, data_type ' +
+                'SELECT table_name, column_name, column_type, data_type ' +
                 'FROM information_schema.columns ' +
                 'WHERE data_type IN (\'enum\', \'set\') and table_schema = ?',
                 ['testschema']
@@ -76,7 +76,7 @@ describe('MysqlDatabase', () => {
             MysqlDBReflection.prototype.queryAsync.returns(Promise.resolve([]))
             await db.getEnumTypes()
             assert.deepEqual(MysqlDBReflection.prototype.queryAsync.getCall(0).args, [
-                'SELECT column_name, column_type, data_type ' +
+                'SELECT table_name, column_name, column_type, data_type ' +
                 'FROM information_schema.columns ' +
                 'WHERE data_type IN (\'enum\', \'set\') ',
                 []
@@ -84,29 +84,29 @@ describe('MysqlDatabase', () => {
         })
         it('handles response', async () => {
             MysqlDBReflection.prototype.queryAsync.returns(Promise.resolve([
-                { column_name: 'column1', column_type: 'enum(\'enum1\')', data_type: 'enum' },
-                { column_name: 'column2', column_type: 'set(\'set1\')', data_type: 'set' }
+                { table_name: 'testschema', column_name: 'column1', column_type: 'enum(\'enum1\')', data_type: 'enum' },
+                { table_name: 'testschema', column_name: 'column2', column_type: 'set(\'set1\')', data_type: 'set' }
             ]))
             const enumTypes = await db.getEnumTypes('testschema')
             assert.deepEqual(enumTypes, {
-                enum_column1: [ 'enum1' ],
-                set_column2: [ 'set1' ]
+                testschema_column1: [ 'enum1' ],
+                testschema_column2: [ 'set1' ]
             })
         })
         it('same column same value is accepted', async () => {
             MysqlDBReflection.prototype.queryAsync.returns(Promise.resolve([
-                { column_name: 'column1', column_type: 'enum(\'enum1\',\'enum2\')', data_type: 'enum' },
-                { column_name: 'column1', column_type: 'enum(\'enum1\',\'enum2\')', data_type: 'enum' }
+                { table_name: 'testschema', column_name: 'column1', column_type: 'enum(\'enum1\',\'enum2\')', data_type: 'enum' },
+                { table_name: 'testschema', column_name: 'column1', column_type: 'enum(\'enum1\',\'enum2\')', data_type: 'enum' }
             ]))
             const enumTypes = await db.getEnumTypes('testschema')
             assert.deepEqual(enumTypes, {
-                enum_column1: [ 'enum1', 'enum2' ]
+                testschema_column1: [ 'enum1', 'enum2' ]
             })
         })
         it('same column different value conflict', async () => {
             MysqlDBReflection.prototype.queryAsync.returns(Promise.resolve([
-                { column_name: 'column1', column_type: 'enum(\'enum1\')', data_type: 'enum' },
-                { column_name: 'column1', column_type: 'enum(\'enum2\')', data_type: 'enum' }
+                { table_name: 'testschema', column_name: 'column1', column_type: 'enum(\'enum1\')', data_type: 'enum' },
+                { table_name: 'testschema', column_name: 'column1', column_type: 'enum(\'enum2\')', data_type: 'enum' }
             ]))
             try {
                 await db.getEnumTypes('testschema')
@@ -135,8 +135,8 @@ describe('MysqlDatabase', () => {
             const schemaTables = await db.getTableDefinition('testtable', 'testschema')
             assert.deepEqual(schemaTables, {
                 column1: { udtName: 'data1', nullable: false },
-                column2: { udtName: 'enum_column2', nullable: true },
-                column3: { udtName: 'set_column3', nullable: true }
+                column2: { udtName: 'testtable_column2', nullable: true },
+                column3: { udtName: 'testtable_column3', nullable: true }
             })
         })
     })


### PR DESCRIPTION
The current logic checks for name collision for enum columns. However this check is global not per table. This caused an issue when multiple tables have enum columns of the same name.

I've changed the naming convention of enum column from `${data_type}_${column_name}` to `${table_name}_${column_name}`.

The generated TypeScript is not backward compatible with previous version because of the name change.