### PR TITLE
Handle upper case columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "scripts": {
-    "lint": "tslint --project tsconfig.json --type-check 'src/**/*.ts' 'test/**/*.test.ts' 'bin/**/*.ts' --exclude '**/*.d.ts'",
+    "lint": "tslint --project tsconfig.json",
     "build": "tsc",
     "dependency-check": "dependency-check . --entry bin/schemats.js --missing --no-dev",
     "test": "npm run lint && npm run build && npm run dependency-check && mocha",

--- a/src/schemaMysql.ts
+++ b/src/schemaMysql.ts
@@ -167,12 +167,19 @@ export class MysqlDatabase implements Database {
                 if (error) {
                     return reject(error)
                 }
-                return resolve(results)
+                return resolve(this.toLowerCaseColumnName(results))
             })
         })
     }
 
     public getDefaultSchema (): string {
         return this.defaultSchema
+    }
+
+    private toLowerCaseColumnName (results: Object[]): Object[] {
+        return results.map((row: any) => Object.keys(row).reduce((newRow, key) => {
+            newRow[key.toLowerCase()] = row[key]
+            return newRow
+        }, {} as any))
     }
 }

--- a/test/integration/cli.test.ts
+++ b/test/integration/cli.test.ts
@@ -11,7 +11,7 @@ describe('schemats cli tool integration testing', () => {
         it('should run without error', () => {
             let {status, stdout, stderr} = spawnSync('node', [
                 'bin/schemats', 'generate',
-                '-c', process.env.POSTGRES_URL,
+                '-c', process.env.POSTGRES_URL as string,
                 '-o', '/tmp/schemats_cli_postgres.ts'
             ], { encoding: 'utf-8' })
             console.log('opopopopop', stdout, stderr)
@@ -27,7 +27,7 @@ describe('schemats cli tool integration testing', () => {
         it('should run without error', () => {
             let {status} = spawnSync('node', [
                 'bin/schemats', 'generate',
-                '-c', process.env.MYSQL_URL,
+                '-c', process.env.MYSQL_URL as string,
                 '-s', 'test',
                 '-o', '/tmp/schemats_cli_postgres.ts'
             ])

--- a/test/testUtility.ts
+++ b/test/testUtility.ts
@@ -1,7 +1,6 @@
 import * as fs from 'mz/fs'
 import { typescriptOfSchema, Database } from '../src/index'
-import Options from '../src/options'
-import * as ts from 'typescript';
+import * as ts from 'typescript'
 
 const diff = require('diff')
 interface IDiffResult {
@@ -11,13 +10,14 @@ interface IDiffResult {
     removed?: boolean
 }
 
-export function compile(fileNames: string[], options: ts.CompilerOptions): boolean {
+export function compile (fileNames: string[], options: ts.CompilerOptions): boolean {
     let program = ts.createProgram(fileNames, options)
     let emitResult = program.emit()
     let exitCode = emitResult.emitSkipped ? 1 : 0
     return exitCode === 0
 }
-export async function compare(goldStandardFile: string, outputFile: string): Promise<boolean> {
+
+export async function compare (goldStandardFile: string, outputFile: string): Promise<boolean> {
 
     let gold = await fs.readFile(goldStandardFile, {encoding: 'utf8'})
     let actual = await fs.readFile(outputFile, {encoding: 'utf8'})
@@ -38,15 +38,14 @@ export async function compare(goldStandardFile: string, outputFile: string): Pro
     }
 }
 
-
-export async function loadSchema(db: Database, file: string) {
+export async function loadSchema (db: Database, file: string) {
     let query = await fs.readFile(file, {
         encoding: 'utf8'
     })
     return await db.query(query)
 }
 
-export async function writeTsFile(inputSQLFile: string, inputConfigFile: string,  outputFile: string, db: Database) {
+export async function writeTsFile (inputSQLFile: string, inputConfigFile: string, outputFile: string, db: Database) {
     await loadSchema(db, inputSQLFile)
     const config: any = require(inputConfigFile)
     let formattedOutput = await typescriptOfSchema(

--- a/test/unit/schemaMysql.test.ts
+++ b/test/unit/schemaMysql.test.ts
@@ -60,6 +60,16 @@ describe('MysqlDatabase', () => {
             const results = await testDb.query('SELECT * FROM test_table')
             assert.deepEqual(results, [])
         })
+        it('query returns with results with columns as lower-case', async () => {
+            (mysql.createConnection as any).returns({
+                query: function query (queryString: string, params: Array<any>, cb: Function) {
+                    cb(null, [{COLUMN_1: 'val1', COLUMN_2: 'val1'}, {COLUMN_1: 'val2', COLUMN_2: 'val2'}])
+                }
+            })
+            const testDb: any = new MysqlDatabase('mysql://user:password@localhost/test')
+            const results = await testDb.query('SELECT * FROM test_table')
+            assert.deepEqual(results, [{column_1: 'val1', column_2: 'val1'}, {column_1: 'val2', column_2: 'val2'}])
+        })
     })
     describe('getEnumTypes', () => {
         it('writes correct query with schema name', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,12 @@
         "dts",
         "test/actual",
         "test/expected",
-        "test/fixture"
+        "test/fixture",
+        "**/*.d.ts"
+    ],
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.test.ts",
+        "bin/**/*.ts"
     ]
 }


### PR DESCRIPTION
This PR handles column names in information_schemata that are in uppercase, (MySql 8).

Fixes #97 