### PR TITLE
added singularTableNames option

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/proxyquire": "^1.3.27",
     "@types/sinon": "^2.1.2",
     "@types/yargs": "^6.3.3",
+    "@types/pluralize": "0.0.29",
     "coveralls": "^2.11.15",
     "del-cli": "^0.2.0",
     "dependency-check": "^2.6.0",
@@ -70,6 +71,7 @@
     "mysql": "^2.13.0",
     "mz": "^2.6.0",
     "pg-promise": "^6.3.6",
+    "pluralize": "^8.0.0",
     "typescript": "^2.7.1",
     "typescript-formatter": "^7.0.1",
     "yargs": "^8.0.1"

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,13 +1,16 @@
 import { camelCase, upperFirst } from 'lodash'
+import { singular } from 'pluralize';
 
 const DEFAULT_OPTIONS: OptionValues = {
     writeHeader: true,
-    camelCase: false
+    camelCase: false,
+    singularTableNames: false
 }
 
 export type OptionValues = {
     camelCase?: boolean
     writeHeader?: boolean // write schemats description header
+    singularTableNames?: boolean
 }
 
 export default class Options {
@@ -18,6 +21,12 @@ export default class Options {
     }
 
     transformTypeName (typename: string) {
+        if (this.options.singularTableNames)
+            typename = singular(typename);
+
+        if (this.options.camelCase)
+            typename = upperFirst(camelCase(typename));
+
         return this.options.camelCase ? upperFirst(camelCase(typename)) : typename
     }
 


### PR DESCRIPTION
Added singalurTableNames to convert table names to singalur using the pluralize [package](https://www.npmjs.com/package/pluralize).

Useful for frameworks like cakephp which require [plural table](https://book.cakephp.org/1.3/en/The-Manual/Basic-Principles-of-CakePHP/CakePHP-Conventions.html#:~:text=Table%20names%20corresponding%20to%20CakePHP,the%20singular%2Fplural%20of%20words.) names.